### PR TITLE
Add code field to Speciality model and GraphQL types

### DIFF
--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -1142,6 +1142,7 @@ class DeletePrescribersMutation(OpenIMISMutation):
 class SpecialityInputType(OpenIMISMutation.Input):
     id = graphene.Int(required=False, read_only=True)
     uuid = graphene.String(required=False)
+    code = graphene.String(max_length=50, required=False)
     speciality = graphene.String(max_length=150, required=True)
     alt_language = graphene.String(max_length=150, required=False)
     json_ext = graphene.types.json.JSONString(required=False)

--- a/claim/gql_queries.py
+++ b/claim/gql_queries.py
@@ -214,6 +214,7 @@ class SpecialityGQLType(DjangoObjectType):
         model = Speciality
         filter_fields = {
             "uuid": ["exact","icontains"],
+            "code": ["exact", "icontains"],
             "speciality": ["exact", "icontains"]
         }
         interfaces = (graphene.relay.Node,)

--- a/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
+++ b/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
@@ -50,6 +50,7 @@ class Migration(migrations.Migration):
                 ('legacy_id', models.IntegerField(blank=True, db_column='LegacyID', null=True)),
                 ('id', models.AutoField(db_column='SpecialityID', primary_key=True, serialize=False)),
                 ('uuid', models.CharField(db_column='SpecialityUUID', default=uuid.uuid4, max_length=36, unique=True)),
+                ('code', models.CharField(blank=True, db_column='SpecialityCode', max_length=150, null=True)),
                 ('speciality', models.CharField(blank=True, db_column='Speciality', max_length=150, null=True)),
                 ('alt_language', models.CharField(blank=True, db_column='AltLanguage', max_length=150, null=True)),
                 ('audit_user_id', models.IntegerField(db_column='AuditUserID')),

--- a/claim/models.py
+++ b/claim/models.py
@@ -630,6 +630,7 @@ class ClaimDedRem(core_models.VersionedModel):
 class Speciality(core_models.VersionedModel, core_models.ExtendableModel):
     id = models.AutoField(db_column='SpecialityID', primary_key=True)
     uuid = models.CharField(db_column='SpecialityUUID', max_length=36, default=uuid.uuid4, unique=True)
+    code = models.CharField(db_column='SpecialityCode', max_length=50, blank=True, null=True)
     speciality = models.CharField(db_column='Speciality', max_length=150, blank=True, null=True)
     alt_language = models.CharField(db_column='AltLanguage', max_length=150, blank=True, null=True)
     audit_user_id = models.IntegerField(db_column='AuditUserID')


### PR DESCRIPTION
Introduces a new 'code' field to the Speciality model, updates the migration, and exposes the field in GraphQL mutations and queries for better identification and filtering of specialities.