### PR TITLE
Use ordered filter fields for specialities and status

### DIFF
--- a/claim/schema.py
+++ b/claim/schema.py
@@ -90,8 +90,8 @@ class Query(graphene.ObjectType):
         orderBy=graphene.List(of_type=graphene.String)
     )
 
-    specialities = graphene.List(SpecialityGQLType)
-    statusOptions = graphene.List(StatusGQLType)
+    specialities = OrderedDjangoFilterConnectionField(SpecialityGQLType)
+    statusOptions = OrderedDjangoFilterConnectionField(StatusGQLType)
 
     def resolve_prescribers(self, info, **kwargs):
         if not info.context.user.has_perms(ClaimConfig.gql_query_claims_perms):


### PR DESCRIPTION
Replaces graphene.List with OrderedDjangoFilterConnectionField for specialities and statusOptions in the Query class to support filtering and ordering in GraphQL queries.