### PR TITLE
Add orderBy argument to specialities and statusOptions

### DIFF
--- a/claim/schema.py
+++ b/claim/schema.py
@@ -90,8 +90,12 @@ class Query(graphene.ObjectType):
         orderBy=graphene.List(of_type=graphene.String)
     )
 
-    specialities = OrderedDjangoFilterConnectionField(SpecialityGQLType)
-    statusOptions = OrderedDjangoFilterConnectionField(StatusGQLType)
+    specialities = OrderedDjangoFilterConnectionField(
+        SpecialityGQLType,
+        orderBy=graphene.List(of_type=graphene.String))
+    statusOptions = OrderedDjangoFilterConnectionField(
+        StatusGQLType,
+        orderBy=graphene.List(of_type=graphene.String))
 
     def resolve_prescribers(self, info, **kwargs):
         if not info.context.user.has_perms(ClaimConfig.gql_query_claims_perms):


### PR DESCRIPTION
The specialities and statusOptions fields now accept an orderBy argument, allowing clients to specify sorting order in GraphQL queries.