### PR TITLE
Rename Prescriber code column to PrescriberCode

### DIFF
--- a/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
+++ b/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('legacy_id', models.IntegerField(blank=True, db_column='LegacyID', null=True)),
                 ('id', models.AutoField(db_column='PrescriberID', primary_key=True, serialize=False)),
                 ('uuid', models.CharField(db_column='PrescriberUUID', default=uuid.uuid4, max_length=36, unique=True)),
-                ('code', models.CharField(db_column='SpecialityCode', max_length=50)),
+                ('code', models.CharField(db_column='PrescriberCode', max_length=50)),
                 ('last_name', models.CharField(db_column='LastName', max_length=100)),
                 ('other_names', models.CharField(db_column='OtherNames', max_length=100)),
                 ('nin', models.CharField(db_column='NIN', max_length=9)),

--- a/claim/models.py
+++ b/claim/models.py
@@ -661,7 +661,7 @@ class Status(models.Model):
 class Prescriber(core_models.VersionedModel, core_models.ExtendableModel):
     id = models.AutoField(db_column='PrescriberID', primary_key=True)
     uuid = models.CharField(db_column='PrescriberUUID', max_length=36, default=uuid.uuid4, unique=True)
-    code = models.CharField(db_column='SpecialityCode', max_length=50) 
+    code = models.CharField(db_column='PrescriberCode', max_length=50) 
     last_name = models.CharField(db_column='LastName', max_length=100)
     other_names = models.CharField(db_column='OtherNames', max_length=100)
     nin = models.CharField(db_column='NIN', max_length=9)


### PR DESCRIPTION
Changed the db_column for the Prescriber model's code field from 'SpecialityCode' to 'PrescriberCode' in both the model and migration to ensure consistency with the database schema.