### PR TITLE
Enforce prescriber authorization for health facility

### DIFF
--- a/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
+++ b/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='claim',
             name='prescriber',
-            field=models.ForeignKey(blank=True, db_column='PrescriberID', null=True, on_delete=django.db.models.deletion.DO_NOTHING, to='claim.prescriber'),
+            field=models.ForeignKey(db_column='PrescriberID', on_delete=django.db.models.deletion.DO_NOTHING, to='claim.prescriber'),
         )
     ]

--- a/claim/models.py
+++ b/claim/models.py
@@ -309,8 +309,7 @@ class Claim(core_models.VersionedModel, core_models.ExtendableModel):
         blank=True, null=True)
             
     prescriber = models.ForeignKey(
-        Prescriber, models.DO_NOTHING, db_column='PrescriberID',
-        blank=True, null=True)
+        Prescriber, models.DO_NOTHING, db_column='PrescriberID')
     
     visit_type = models.CharField(
         db_column='VisitType', max_length=1, blank=True, null=True)

--- a/claim/services.py
+++ b/claim/services.py
@@ -436,6 +436,10 @@ def claim_create(data, user, autogenerate_code = False):
     if prescriber_uuid:
         prescriber = Prescriber.objects.filter(uuid=prescriber_uuid).first()
         if prescriber:
+            health_facility_id= data.get('health_facility_id')
+            if prescriber.main_health_facility.id != health_facility_id and \
+                (not prescriber.authorized_health_facilities.filter(id=health_facility_id).exists()):
+                raise ValidationError(_("mutation.prescriber_not_authorized_in_hf"))
             data["prescriber_id"] = prescriber.id
     restore = data.pop('restore', None)
     autogenerate_code = data.pop('autogenerate', None)
@@ -456,6 +460,10 @@ def claim_update(claim, data, user):
     prescriber_uuid = data.pop("prescriber_uuid", None)
     if prescriber_uuid:
         prescriber = Prescriber.objects.filter(uuid=prescriber_uuid).first()
+        health_facility_id= data.get('health_facility_id')
+        if prescriber.main_health_facility.id != health_facility_id and \
+            (not prescriber.authorized_health_facilities.filter(id=health_facility_id).exists()):
+            raise ValidationError(_("mutation.prescriber_not_authorized_in_hf"))
         if prescriber:
             data["prescriber_id"] = prescriber.id
     claim.save_history()


### PR DESCRIPTION
Added validation in claim creation and update to ensure the selected prescriber is authorized for the specified health facility. Removed blank and null options from the prescriber ForeignKey in the Claim model and migration to align with new validation logic.