### PR TITLE
Remove location app dependency from claim migrations

### DIFF
--- a/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
+++ b/claim/migrations/0032_prescriber_speciality_status_claim_care_type_and_more.py
@@ -12,7 +12,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('core', '0028_alter_moduleconfiguration_module'),
-        ('location', '0022_alter_location_code'),
         ('claim', '0031_auto_20250419_1400'),
     ]
 

--- a/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
+++ b/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('location', '0022_alter_location_code'),
         ('claim', '0032_prescriber_speciality_status_claim_care_type_and_more'),
     ]
 


### PR DESCRIPTION
Eliminated the dependency on the 'location' app migration 0022 in claim migration files 0032 and 0033. This change helps decouple claim migrations from location migrations, potentially resolving migration dependency issues.