### PR TITLE
Make prescriber field optional in Claim model

### DIFF
--- a/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
+++ b/claim/migrations/0033_claim_care_type_claim_prescriber_claim_refer_from_and_more.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='claim',
             name='prescriber',
-            field=models.ForeignKey(db_column='PrescriberID', on_delete=django.db.models.deletion.DO_NOTHING, to='claim.prescriber'),
+            field=models.ForeignKey(null=True,blank=True,db_column='PrescriberID', on_delete=django.db.models.deletion.DO_NOTHING, to='claim.prescriber'),
         )
     ]

--- a/claim/models.py
+++ b/claim/models.py
@@ -309,7 +309,7 @@ class Claim(core_models.VersionedModel, core_models.ExtendableModel):
         blank=True, null=True)
             
     prescriber = models.ForeignKey(
-        Prescriber, models.DO_NOTHING, db_column='PrescriberID')
+        Prescriber, models.DO_NOTHING, db_column='PrescriberID',null=True,blank=True)
     
     visit_type = models.CharField(
         db_column='VisitType', max_length=1, blank=True, null=True)


### PR DESCRIPTION
Updated the Claim model and its migration to allow the prescriber ForeignKey to be null and blank. This change makes the prescriber field optional for claims.